### PR TITLE
Various CSS tweaks for smaller size screens

### DIFF
--- a/_sass/_mdl.scss
+++ b/_sass/_mdl.scss
@@ -111,6 +111,11 @@ html, body p{
 
 .demo-footer {
   padding-left: 40px;
+  min-height: 2.5em;
+}
+
+.demo-layout.is-small-screen .demo-footer {
+  min-height: 2.1em;
 }
 
 .demo-footer .mdl-mini-footer--link-list a {
@@ -120,6 +125,11 @@ html, body p{
 .intro {
   font-size: 20px;
   line-height: 1.5;
+}
+
+.demo-layout.is-small-screen .intro {
+  font-size: 16px;
+  line-height: 1.4;
 }
 
 .icon {
@@ -136,11 +146,20 @@ html, body p{
     }
 }
 
+
+.demo-layout.is-small-screen .mainlogo{
+  width: 90px;
+  height: 90px;
+  margin-top: 28px;
+  max-width: 100%;
+}
+
 .mainlogo {
   margin: auto;
   margin-top: 42px;
   width: 100px;
   height: 100px;
+  max-width: 100%;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ layout: default
                 <div class="mdl-grid mdl-grid--no-spacing projectcontainer">
                   <h5 class="largetitle">{{ post.title }}</h5>
                   {{ post.excerpt }}
-                  <a class="mdl-button" href="{{ post.url }}">Read on...</a>
+                  <a class="details" href="{{ post.url }}">Read on...</a>
                 </div>
               {% endfor %}
               <a href="posts" class="mdl-button">More News</a>
@@ -155,7 +155,7 @@ layout: default
                 </div>
 
                 <div class="section__circle-container mdl-cell mdl-cell--4-col mdl-cell--1-col-phone member">
-                  <p>Matthew P John</p>
+                  <p>Matthew P. John</p>
                 </div>
 
                 <div class="section__circle-container mdl-cell mdl-cell--4-col mdl-cell--1-col-phone member">


### PR DESCRIPTION
News post “read more” links are now styled smaller to match publication
“detail” links
Rough fix for the footer size issue on pages with long content
